### PR TITLE
Fix install from source in gcc12 (noexcept)

### DIFF
--- a/pgbm/sklearn/splitting.pyx
+++ b/pgbm/sklearn/splitting.pyx
@@ -1086,7 +1086,7 @@ cdef class Splitter:
             return
 
         qsort(cat_infos, n_used_bins, sizeof(categorical_info),
-              compare_cat_infos)
+              &compare_cat_infos)
 
         loss_current_node = _loss_from_value(value, sum_gradients)
 
@@ -2152,7 +2152,7 @@ cdef class SplitterWithVariance:
             return
 
         qsort(cat_infos, n_used_bins, sizeof(categorical_info),
-              compare_cat_infos)
+              &compare_cat_infos)
 
         loss_current_node = _loss_from_value(value, sum_gradients)
 
@@ -2269,7 +2269,7 @@ cdef class SplitterWithVariance:
 
         free(cat_infos)
 
-cdef int compare_cat_infos(const void * a, const void * b) nogil:
+cdef int compare_cat_infos(const void * a, const void * b) noexcept nogil:
     return -1 if (<categorical_info *>a).value < (<categorical_info *>b).value else 1
 
 cdef inline Y_DTYPE_C _split_gain(


### PR DESCRIPTION

Fix noexcept error in gcc12 env

[7/8] Cythonizing pgbm/sklearn/splitting.pyx

Error compiling Cython file:
------------------------------------------------------------
...
        if n_used_bins <= 1:
            free(cat_infos)
            return

        qsort(cat_infos, n_used_bins, sizeof(categorical_info),
              compare_cat_infos)
              ^
------------------------------------------------------------

pgbm/sklearn/splitting.pyx:1089:14: Cannot assign type 'int (const void *, const void *) except? -1 nogil' to 'int (*)(const void *, const void *) noexcept nogil'

Error compiling Cython file:
------------------------------------------------------------
...
        if n_used_bins <= 1:
            free(cat_infos)
            return

        qsort(cat_infos, n_used_bins, sizeof(categorical_info),
              compare_cat_infos)
              ^
------------------------------------------------------------
