### PR TITLE
Add Python 3.11 wheels

### DIFF
--- a/.github/scripts/build_wheels.sh
+++ b/.github/scripts/build_wheels.sh
@@ -18,7 +18,7 @@ if [[ "$RUNNER_OS" == "macOS" ]]; then
         export MACOSX_DEPLOYMENT_TARGET=12.0
         OPENMP_URL="https://anaconda.org/conda-forge/llvm-openmp/11.1.0/download/osx-arm64/llvm-openmp-11.1.0-hf3c4609_1.tar.bz2"
     else
-        export MACOSX_DEPLOYMENT_TARGET=10.9
+        export MACOSX_DEPLOYMENT_TARGET=10.13
         OPENMP_URL="https://anaconda.org/conda-forge/llvm-openmp/11.1.0/download/osx-64/llvm-openmp-11.1.0-hda6cdc1_1.tar.bz2"
     fi
 

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -14,9 +14,9 @@ jobs:
       matrix:
         include:
           # Window 64 bit
-          # - os: windows-2019
-          #   python: 38
-          #   platform_id: win_amd64
+          - os: windows-latest
+            python: 38
+            platform_id: win_amd64
           - os: windows-latest
             python: 39
             platform_id: win_amd64
@@ -31,10 +31,10 @@ jobs:
           #   platform_id: win_amd64
           
             # Linux 64 bit manylinux2014
-          # - os: ubuntu-latest
-          #   python: 38
-          #   platform_id: manylinux_x86_64
-          #   manylinux_image: manylinux2014
+          - os: ubuntu-latest
+            python: 38
+            platform_id: manylinux_x86_64
+            manylinux_image: manylinux2014
           - os: ubuntu-latest
             python: 39
             platform_id: manylinux_x86_64
@@ -53,9 +53,9 @@ jobs:
           #   manylinux_image: manylinux2014
 
           # MacOS x86_64
-          # - os: macos-latest
-          #   python: 38
-          #   platform_id: macosx_x86_64
+          - os: macos-latest
+            python: 38
+            platform_id: macosx_x86_64
           - os: macos-latest
             python: 39
             platform_id: macosx_x86_64
@@ -73,15 +73,15 @@ jobs:
           # - os: macos-latest
           #   python: 38
           #   platform_id: macosx_arm64
-          - os: macos-latest
-            python: 39
-            platform_id: macosx_arm64
-          - os: macos-latest
-            python: 310
-            platform_id: macosx_arm64
-          - os: macos-latest
-            python: 311
-            platform_id: macosx_arm64          
+          # - os: macos-latest
+          #   python: 39
+          #   platform_id: macosx_arm64
+          # - os: macos-latest
+          #   python: 310
+          #   platform_id: macosx_arm64
+          # - os: macos-latest
+          #   python: 311
+          #   platform_id: macosx_arm64          
           # - os: macos-latest
           #   python: 312
           #   platform_id: macosx_arm64     
@@ -96,7 +96,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.9'  # update once build dependencies are available
+          python-version: '3.8'  # update once build dependencies are available
       
       - name: Build wheels
         env:
@@ -128,7 +128,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.9'  # update once build dependencies are available
+          python-version: '3.8'  # update once build dependencies are available
 
       - name: Build source distribution
         run: bash .github/scripts/build_source.sh

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -5,7 +5,7 @@ on: [push, pull_request, workflow_call]
 
 jobs:
   build_wheels:
-    name: Build wheel for cp${{ matrix.python }}-${{ matrix.platform_id }}-${{ matrix.manylinux_image }}
+    name: Build wheel for cp${{ matrix.python }}-${{ matrix.platform_id }}
     runs-on: ${{ matrix.os }}
 
     strategy:
@@ -14,7 +14,7 @@ jobs:
       matrix:
         include:
           # Window 64 bit
-          - os: windows-latest
+          - os: windows-2019
             python: 38
             platform_id: win_amd64
           - os: windows-latest
@@ -26,11 +26,8 @@ jobs:
           - os: windows-latest
             python: 311
             platform_id: win_amd64
-          # - os: windows-latest
-          #   python: 312
-          #   platform_id: win_amd64
           
-            # Linux 64 bit manylinux2014
+          # Linux 64 bit manylinux2014
           - os: ubuntu-latest
             python: 38
             platform_id: manylinux_x86_64
@@ -47,44 +44,76 @@ jobs:
             python: 311
             platform_id: manylinux_x86_64
             manylinux_image: manylinux2014
-          # - os: ubuntu-latest
-          #   python: 312
-          #   platform_id: manylinux_x86_64
-          #   manylinux_image: manylinux2014
 
-          # MacOS x86_64
-          - os: macos-latest
+          # MacOS 12 x86_64
+          - os: macos-12
             python: 38
             platform_id: macosx_x86_64
-          - os: macos-latest
+          - os: macos-12
             python: 39
             platform_id: macosx_x86_64
-          - os: macos-latest
+          - os: macos-12
             python: 310
             platform_id: macosx_x86_64
-          - os: macos-latest
+          - os: macos-12
             python: 311
             platform_id: macosx_x86_64
-          # - os: macos-latest
-          #   python: 312
-          #   platform_id: macosx_x86_64
 
-          # MacOS arm64
-          # - os: macos-latest
-          #   python: 38
-          #   platform_id: macosx_arm64
-          # - os: macos-latest
-          #   python: 39
-          #   platform_id: macosx_arm64
-          # - os: macos-latest
-          #   python: 310
-          #   platform_id: macosx_arm64
-          # - os: macos-latest
-          #   python: 311
-          #   platform_id: macosx_arm64          
-          # - os: macos-latest
-          #   python: 312
-          #   platform_id: macosx_arm64     
+          # MacOS 13 x86_64
+          - os: macos-13
+            python: 38
+            platform_id: macosx_x86_64
+          - os: macos-13
+            python: 39
+            platform_id: macosx_x86_64
+          - os: macos-13
+            python: 310
+            platform_id: macosx_x86_64
+          - os: macos-13
+            python: 311
+            platform_id: macosx_x86_64
+
+          # MacOS 14 x86_64
+          - os: macos-14-large
+            python: 38
+            platform_id: macosx_x86_64
+          - os: macos-14-large
+            python: 39
+            platform_id: macosx_x86_64
+          - os: macos-14-large
+            python: 310
+            platform_id: macosx_x86_64
+          - os: macos-14-large
+            python: 311
+            platform_id: macosx_x86_64            
+
+          # MacOS 13 arm64
+          - os: macos-13-xlarge
+            python: 38
+            platform_id: macosx_arm64
+          - os: macos-13-xlarge
+            python: 39
+            platform_id: macosx_arm64
+          - os: macos-13-xlarge
+            python: 310
+            platform_id: macosx_arm64
+          - os: macos-13-xlarge
+            python: 311
+            platform_id: macosx_arm64            
+
+          # MacOS 14 arm64
+          - os: macos-14
+            python: 38
+            platform_id: macosx_arm64
+          - os: macos-14
+            python: 39
+            platform_id: macosx_arm64
+          - os: macos-14
+            python: 310
+            platform_id: macosx_arm64
+          - os: macos-14
+            python: 311
+            platform_id: macosx_arm64              
 
     steps:
       - name: Checkout PGBM

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -27,7 +27,7 @@ jobs:
             python: 311
             platform_id: win_amd64
           
-          # Linux 64 bit manylinux2014
+            # Linux 64 bit manylinux2014
           - os: ubuntu-latest
             python: 38
             platform_id: manylinux_x86_64
@@ -45,49 +45,21 @@ jobs:
             platform_id: manylinux_x86_64
             manylinux_image: manylinux2014
 
-          # MacOS 12 x86_64
-          - os: macos-12
+          # MacOS x86_64
+          - os: macos-latest
             python: 38
             platform_id: macosx_x86_64
-          - os: macos-12
+          - os: macos-latest
             python: 39
             platform_id: macosx_x86_64
-          - os: macos-12
+          - os: macos-latest
             python: 310
             platform_id: macosx_x86_64
-          - os: macos-12
+          - os: macos-latest
             python: 311
             platform_id: macosx_x86_64
 
-          # MacOS 13 x86_64
-          - os: macos-13
-            python: 38
-            platform_id: macosx_x86_64
-          - os: macos-13
-            python: 39
-            platform_id: macosx_x86_64
-          - os: macos-13
-            python: 310
-            platform_id: macosx_x86_64
-          - os: macos-13
-            python: 311
-            platform_id: macosx_x86_64
-
-          # MacOS 14 x86_64
-          - os: macos-14-large
-            python: 38
-            platform_id: macosx_x86_64
-          - os: macos-14-large
-            python: 39
-            platform_id: macosx_x86_64
-          - os: macos-14-large
-            python: 310
-            platform_id: macosx_x86_64
-          - os: macos-14-large
-            python: 311
-            platform_id: macosx_x86_64            
-
-          # MacOS 13 arm64
+          # MacOS arm64
           - os: macos-13-xlarge
             python: 38
             platform_id: macosx_arm64
@@ -100,20 +72,6 @@ jobs:
           - os: macos-13-xlarge
             python: 311
             platform_id: macosx_arm64            
-
-          # MacOS 14 arm64
-          - os: macos-14
-            python: 38
-            platform_id: macosx_arm64
-          - os: macos-14
-            python: 39
-            platform_id: macosx_arm64
-          - os: macos-14
-            python: 310
-            platform_id: macosx_arm64
-          - os: macos-14
-            python: 311
-            platform_id: macosx_arm64              
 
     steps:
       - name: Checkout PGBM

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -60,16 +60,16 @@ jobs:
             platform_id: macosx_x86_64
 
           # MacOS arm64
-          - os: macos-13-xlarge
+          - os: macos-latest
             python: 38
             platform_id: macosx_arm64
-          - os: macos-13-xlarge
+          - os: macos-14
             python: 39
             platform_id: macosx_arm64
-          - os: macos-13-xlarge
+          - os: macos-14
             python: 310
             platform_id: macosx_arm64
-          - os: macos-13-xlarge
+          - os: macos-14
             python: 311
             platform_id: macosx_arm64            
 

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -14,9 +14,9 @@ jobs:
       matrix:
         include:
           # Window 64 bit
-          - os: windows-2019
-            python: 38
-            platform_id: win_amd64
+          # - os: windows-2019
+          #   python: 38
+          #   platform_id: win_amd64
           - os: windows-latest
             python: 39
             platform_id: win_amd64
@@ -26,15 +26,15 @@ jobs:
           - os: windows-latest
             python: 311
             platform_id: win_amd64
-          - os: windows-latest
-            python: 312
-            platform_id: win_amd64
+          # - os: windows-latest
+          #   python: 312
+          #   platform_id: win_amd64
           
             # Linux 64 bit manylinux2014
-          - os: ubuntu-latest
-            python: 38
-            platform_id: manylinux_x86_64
-            manylinux_image: manylinux2014
+          # - os: ubuntu-latest
+          #   python: 38
+          #   platform_id: manylinux_x86_64
+          #   manylinux_image: manylinux2014
           - os: ubuntu-latest
             python: 39
             platform_id: manylinux_x86_64
@@ -47,15 +47,15 @@ jobs:
             python: 311
             platform_id: manylinux_x86_64
             manylinux_image: manylinux2014
-          - os: ubuntu-latest
-            python: 312
-            platform_id: manylinux_x86_64
-            manylinux_image: manylinux2014
+          # - os: ubuntu-latest
+          #   python: 312
+          #   platform_id: manylinux_x86_64
+          #   manylinux_image: manylinux2014
 
           # MacOS x86_64
-          - os: macos-latest
-            python: 38
-            platform_id: macosx_x86_64
+          # - os: macos-latest
+          #   python: 38
+          #   platform_id: macosx_x86_64
           - os: macos-latest
             python: 39
             platform_id: macosx_x86_64
@@ -65,14 +65,14 @@ jobs:
           - os: macos-latest
             python: 311
             platform_id: macosx_x86_64
-          - os: macos-latest
-            python: 312
-            platform_id: macosx_x86_64
+          # - os: macos-latest
+          #   python: 312
+          #   platform_id: macosx_x86_64
 
           # MacOS arm64
-          - os: macos-latest
-            python: 38
-            platform_id: macosx_arm64
+          # - os: macos-latest
+          #   python: 38
+          #   platform_id: macosx_arm64
           - os: macos-latest
             python: 39
             platform_id: macosx_arm64
@@ -82,9 +82,9 @@ jobs:
           - os: macos-latest
             python: 311
             platform_id: macosx_arm64          
-          - os: macos-latest
-            python: 312
-            platform_id: macosx_arm64     
+          # - os: macos-latest
+          #   python: 312
+          #   platform_id: macosx_arm64     
 
     steps:
       - name: Checkout PGBM
@@ -96,7 +96,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.8'  # update once build dependencies are available
+          python-version: '3.9'  # update once build dependencies are available
       
       - name: Build wheels
         env:
@@ -128,7 +128,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.8'  # update once build dependencies are available
+          python-version: '3.9'  # update once build dependencies are available
 
       - name: Build source distribution
         run: bash .github/scripts/build_source.sh

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -63,13 +63,13 @@ jobs:
           - os: macos-latest
             python: 38
             platform_id: macosx_arm64
-          - os: macos-14
+          - os: macos-latest
             python: 39
             platform_id: macosx_arm64
-          - os: macos-14
+          - os: macos-latest
             python: 310
             platform_id: macosx_arm64
-          - os: macos-14
+          - os: macos-latest
             python: 311
             platform_id: macosx_arm64            
 

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -23,8 +23,14 @@ jobs:
           - os: windows-latest
             python: 310
             platform_id: win_amd64
-
-          # Linux 64 bit manylinux2014
+          - os: windows-latest
+            python: 311
+            platform_id: win_amd64
+          - os: windows-latest
+            python: 312
+            platform_id: win_amd64
+          
+            # Linux 64 bit manylinux2014
           - os: ubuntu-latest
             python: 38
             platform_id: manylinux_x86_64
@@ -33,10 +39,16 @@ jobs:
             python: 39
             platform_id: manylinux_x86_64
             manylinux_image: manylinux2014
-
-          # NumPy on Python 3.10 only supports 64bit and is only available with manylinux2014
           - os: ubuntu-latest
             python: 310
+            platform_id: manylinux_x86_64
+            manylinux_image: manylinux2014
+          - os: ubuntu-latest
+            python: 311
+            platform_id: manylinux_x86_64
+            manylinux_image: manylinux2014
+          - os: ubuntu-latest
+            python: 312
             platform_id: manylinux_x86_64
             manylinux_image: manylinux2014
 
@@ -50,6 +62,12 @@ jobs:
           - os: macos-latest
             python: 310
             platform_id: macosx_x86_64
+          - os: macos-latest
+            python: 311
+            platform_id: macosx_x86_64
+          - os: macos-latest
+            python: 312
+            platform_id: macosx_x86_64
 
           # MacOS arm64
           - os: macos-latest
@@ -61,6 +79,12 @@ jobs:
           - os: macos-latest
             python: 310
             platform_id: macosx_arm64
+          - os: macos-latest
+            python: 311
+            platform_id: macosx_arm64          
+          - os: macos-latest
+            python: 312
+            platform_id: macosx_arm64     
 
     steps:
       - name: Checkout PGBM
@@ -72,7 +96,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.9'  # update once build dependencies are available
+          python-version: '3.8'  # update once build dependencies are available
       
       - name: Build wheels
         env:
@@ -104,7 +128,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.9'  # update once build dependencies are available
+          python-version: '3.8'  # update once build dependencies are available
 
       - name: Build source distribution
         run: bash .github/scripts/build_source.sh

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
 ## 2.3.0 ##
-* Added Python 3.11 and 3.12 testing scripts to wheel
-* Update scikit-learn dependency requirement to 1.2
+* Added Python 3.11 testing scripts to wheel
+* Update scikit-learn minimum dependency requirement to 1.2
+* Update MacOSX minimum dependency to MacOSX 10.13
 
 ## 2.1.2 ##
 * Fixed bug in sklearn cython code

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+## 2.3.0 ##
+* Added Python 3.11 and 3.12 testing scripts to wheel
+* Update scikit-learn dependency requirement to 1.2
+
 ## 2.1.2 ##
 * Fixed bug in sklearn cython code
 

--- a/pgbm/sklearn/tests/test_grower.py
+++ b/pgbm/sklearn/tests/test_grower.py
@@ -555,7 +555,7 @@ def test_ohe_equivalence(min_samples_leaf, n_unique_categories, target):
     n_samples = 10_000
     X_binned = rng.randint(0, n_unique_categories, size=(n_samples, 1), dtype=np.uint8)
 
-    X_ohe = OneHotEncoder(sparse=False).fit_transform(X_binned)
+    X_ohe = OneHotEncoder(sparse_output=False).fit_transform(X_binned)
     X_ohe = np.asfortranarray(X_ohe).astype(np.uint8)
 
     if target == "equal":

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ if __name__ == "__main__":
             "Programming Language :: Python :: 3.8",
             "License :: OSI Approved :: Apache Software License",
             "Operating System :: OS Independent"],
-        python_requires='>=3.8',
+        python_requires='>=3.9,<=3.11',
         install_requires=["scikit-learn>=1.2.0",
                         "ninja>=1.10.2.2",
                         "numba>=0.56"],

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ if __name__ == "__main__":
             "Programming Language :: Python :: 3.8",
             "License :: OSI Approved :: Apache Software License",
             "Operating System :: OS Independent"],
-        python_requires='>=3.9,<=3.11',
+        python_requires='>=3.8,<3.12',
         install_requires=["scikit-learn>=1.2.0",
                         "ninja>=1.10.2.2",
                         "numba>=0.56"],

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ for extension in extensions:
 if __name__ == "__main__":
     setup(
         name="pgbm",
-        version="2.2.0",
+        version="2.3.0",
         description="Probabilistic Gradient Boosting Machines",
         author="Olivier Sprangers",
         author_email="o.r.sprangers@uva.nl",
@@ -71,7 +71,7 @@ if __name__ == "__main__":
             "License :: OSI Approved :: Apache Software License",
             "Operating System :: OS Independent"],
         python_requires='>=3.8',
-        install_requires=["scikit-learn>=1.1.2",
+        install_requires=["scikit-learn>=1.2.0",
                         "ninja>=1.10.2.2",
                         "numba>=0.56"],
         zip_safe=False,


### PR DESCRIPTION
This adds automatic building of Python 3.11 wheels to supported platforms. This should fix #25.